### PR TITLE
align json-logger dep in test project with json-logger

### DIFF
--- a/json-logger-test-app/pom.xml
+++ b/json-logger-test-app/pom.xml
@@ -178,7 +178,7 @@
 		<dependency>
 			<groupId>cc568b69-a181-4d4c-b044-90054c52897b</groupId>
 			<artifactId>json-logger-module</artifactId>
-			<version>1.1.0</version>
+			<version>1.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.mulesoft.munit</groupId>


### PR DESCRIPTION
Aligns dependency in the test project to match the json-logger-module that's installed. I'm getting build errors otherwise.