### PR TITLE
Use correlationId instead of eventId as the key for the elapsed timer

### DIFF
--- a/json-logger/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
+++ b/json-logger/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
@@ -89,9 +89,12 @@ public class JsonloggerOperations {
 
         initLoggerCategory(loggerProcessor.getCategory());
 
+        LOGGER.debug("correlationInfo.getEventId(): " + correlationInfo.getEventId());
+        LOGGER.debug("correlationInfo.getCorrelationId(): " + correlationInfo.getCorrelationId());
+
         try {
             // Add cache entry for initial timestamp based on unique EventId
-            initialTimestamp = config.getCachedTimerTimestamp(correlationInfo.getEventId(), initialTimestamp);
+            initialTimestamp = config.getCachedTimerTimestamp(correlationInfo.getCorrelationId(), initialTimestamp);
         } catch (Exception e) {
             LOGGER.error("initialTimestamp could not be retrieved from the cache config. Defaulting to current System.currentTimeMillis()", e);
         }
@@ -102,7 +105,7 @@ public class JsonloggerOperations {
         //config.printTimersKeys();
         if (elapsed == 0) {
             LOGGER.debug("configuring flowListener....");
-            flowListener.onComplete(new TimerRemoverRunnable(correlationInfo.getEventId(), config));
+            flowListener.onComplete(new TimerRemoverRunnable(correlationInfo.getCorrelationId(), config));
         } else {
             LOGGER.debug("flowListener already configured");
         }
@@ -257,9 +260,12 @@ public class JsonloggerOperations {
 
         initLoggerCategory(category);
 
+        LOGGER.debug("correlationInfo.getEventId(): " + correlationInfo.getEventId());
+        LOGGER.debug("correlationInfo.getCorrelationId(): " + correlationInfo.getCorrelationId());
+
         try {
             // Add cache entry for initial timestamp based on unique EventId
-            initialTimestamp = configs.getConfig(configurationRef).getCachedTimerTimestamp(correlationInfo.getEventId(), initialTimestamp);
+            initialTimestamp = configs.getConfig(configurationRef).getCachedTimerTimestamp(correlationInfo.getCorrelationId(), initialTimestamp);
         } catch (Exception e) {
             LOGGER.error("initialTimestamp could not be retrieved from the cache config. Defaulting to current System.currentTimeMillis()", e);
         }
@@ -270,7 +276,7 @@ public class JsonloggerOperations {
         //config.printTimersKeys();
         if (elapsed == 0) {
             LOGGER.debug("configuring flowListener....");
-            flowListener.onComplete(new TimerRemoverRunnable(correlationInfo.getEventId(), configs.getConfig(configurationRef)));
+            flowListener.onComplete(new TimerRemoverRunnable(correlationInfo.getCorrelationId(), configs.getConfig(configurationRef)));
         } else {
             LOGGER.debug("flowListener already configured");
         }


### PR DESCRIPTION
This pull request fixes mulesoft-consulting/json-logger#20 by changing the key of the timer from eventId to correlationId so that it doesn't change between calls to the JSON logger for an API call.

I left the two debug level logging statements that I used to troubleshoot as they may be helpful if a similar situation arises in the future.