### PR TITLE
Vulnerabilities fix (Mule Runtime 4.3 + required)

### DIFF
--- a/json-logger/README.md
+++ b/json-logger/README.md
@@ -1,5 +1,10 @@
 # Json-logger Extension
 
+## 2.10.0 version - Release notes
+
+* Minimum supported mule runtime 4.3
+* Upgraded dependencies to fix known vulnerabilities
+
 ## 2.0.1 version - Release notes
 
 Bug fixes:

--- a/json-logger/README.md
+++ b/json-logger/README.md
@@ -1,6 +1,6 @@
 # Json-logger Extension
 
-## 2.10.0 version - Release notes
+## 2.1.0 version - Release notes
 
 * Minimum supported mule runtime 4.3
 * Upgraded dependencies to fix known vulnerabilities

--- a/json-logger/pom.xml
+++ b/json-logger/pom.xml
@@ -4,17 +4,30 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>ORG_ID_TOKEN</groupId>
+    <groupId>1dc579a2-2b87-4c16-980e-bd69ae513459</groupId>
     <artifactId>json-logger</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
     <packaging>mule-extension</packaging>
     <name>JSON Logger - Mule 4</name>
 
     <parent>
         <groupId>org.mule.extensions</groupId>
         <artifactId>mule-modules-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.3.2</version>
     </parent>
+
+    <properties>
+        <mule.version>4.3.0-20220922</mule.version>
+        <mule.weave.version>2.5.0-20220921</mule.weave.version>
+        <mule.sdk.version>1.3.0-20220922</mule.sdk.version>
+        <mule.api.version>1.3.0-20220922</mule.api.version>
+        <mule.metadata.version>1.3.0-20220922</mule.metadata.version>
+        <mule.extensions.ast.loader.version>1.2.0</mule.extensions.ast.loader.version>
+        <mule.extensions.maven.plugin.version>1.3.0</mule.extensions.maven.plugin.version>
+        <mule.app.plugins.maven.plugin.version>1.7.0</mule.app.plugins.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.1.1</munit.extensions.maven.plugin.version>
+        <munit.version>2.3.6</munit.version>
+    </properties>
 
     <build>
         <plugins>
@@ -69,9 +82,19 @@
 
     <dependencies>
         <dependency>
+            <artifactId>snakeyaml</artifactId>
+            <groupId>org.yaml</groupId>
+            <version>1.32</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
+            <version>2.13.4.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -91,7 +114,7 @@
         <dependency>
             <groupId>org.mule.connectors</groupId>
             <artifactId>mule-jms-connector</artifactId>
-            <version>1.6.3</version>
+            <version>1.8.4</version>
             <classifier>mule-plugin</classifier>
             <scope>provided</scope>
         </dependency>
@@ -111,13 +134,26 @@
                     <artifactId>async-http-client</artifactId>
                     <groupId>com.ning</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>spring-core</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
             </exclusions>
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.4.0</version>
+            <version>2.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/json-logger/pom.xml
+++ b/json-logger/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>1dc579a2-2b87-4c16-980e-bd69ae513459</groupId>
+    <groupId>ORG_ID_TOKEN</groupId>
     <artifactId>json-logger</artifactId>
     <version>2.1.0</version>
     <packaging>mule-extension</packaging>

--- a/json-logger/pom.xml
+++ b/json-logger/pom.xml
@@ -25,8 +25,10 @@
         <mule.extensions.ast.loader.version>1.2.0</mule.extensions.ast.loader.version>
         <mule.extensions.maven.plugin.version>1.3.0</mule.extensions.maven.plugin.version>
         <mule.app.plugins.maven.plugin.version>1.7.0</mule.app.plugins.maven.plugin.version>
-        <munit.extensions.maven.plugin.version>1.1.1</munit.extensions.maven.plugin.version>
-        <munit.version>2.3.6</munit.version>
+        <munit.extensions.maven.plugin.version>1.1.2</munit.extensions.maven.plugin.version>
+        <munit.version>2.3.8</munit.version>
+        <mule.maven.plugin.version>3.3.5</mule.maven.plugin.version>
+        <skipJavaTests>true</skipJavaTests>
     </properties>
 
     <build>

--- a/json-logger/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
+++ b/json-logger/src/main/java/org/mule/extension/jsonlogger/internal/JsonloggerOperations.java
@@ -20,6 +20,7 @@ import org.mule.runtime.api.transformation.TransformationService;
 import org.mule.runtime.extension.api.annotation.Expression;
 import org.mule.runtime.extension.api.annotation.execution.Execution;
 import org.mule.runtime.extension.api.annotation.param.Config;
+import org.mule.runtime.extension.api.annotation.param.MediaType;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
@@ -239,6 +240,7 @@ public class JsonloggerOperations {
      * Log scope
      */
     @Execution(ExecutionType.BLOCKING)
+    @MediaType("application/json")
     public void loggerScope(@DisplayName("Module configuration") @Example("JSON_Logger_Config") @Summary("Indicate which Global config should be associated with this Scope.") String configurationRef,
                             @Optional(defaultValue="INFO") Priority priority,
                             @Optional(defaultValue="OUTBOUND_REQUEST_SCOPE") ScopeTracePoint scopeTracePoint,

--- a/template-files/settings.xml
+++ b/template-files/settings.xml
@@ -1,292 +1,83 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
-<!--
- | This is the configuration file for Maven. It can be specified at two levels:
- |
- |  1. User Level. This settings.xml file provides configuration for a single user,
- |                 and is normally provided in ${user.home}/.m2/settings.xml.
- |
- |                 NOTE: This location can be overridden with the CLI option:
- |
- |                 -s /path/to/user/settings.xml
- |
- |  2. Global Level. This settings.xml file provides configuration for all Maven
- |                 users on a machine (assuming they're all using the same Maven
- |                 installation). It's normally provided in
- |                 ${maven.conf}/settings.xml.
- |
- |                 NOTE: This location can be overridden with the CLI option:
- |
- |                 -gs /path/to/global/settings.xml
- |
- | The sections in this sample file are intended to give you a running start at
- | getting the most out of your Maven installation. Where appropriate, the default
- | values (values used when the setting is not specified) are provided.
- |
- |-->
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <!-- localRepository
-   | The path to the local repository maven will use to store artifacts.
-   |
-   | Default: ${user.home}/.m2/repository
-  <localRepository>/path/to/local/repo</localRepository>
-  -->
-
-  <!-- interactiveMode
-   | This will determine whether maven prompts you when it needs input. If set to false,
-   | maven will use a sensible default value, perhaps based on some other setting, for
-   | the parameter in question.
-   |
-   | Default: true
-  <interactiveMode>true</interactiveMode>
-  -->
-
-  <!-- offline
-   | Determines whether maven should attempt to connect to the network when executing a build.
-   | This will have an effect on artifact downloads, artifact deployment, and others.
-   |
-   | Default: false
-  <offline>false</offline>
-  -->
-
-  <!-- pluginGroups
-   | This is a list of additional group identifiers that will be searched when resolving plugins by their prefix, i.e.
-   | when invoking a command line like "mvn prefix:goal". Maven will automatically add the group identifiers
-   | "org.apache.maven.plugins" and "org.codehaus.mojo" if these are not already contained in the list.
-   |-->
-  <pluginGroups>
-    <!-- pluginGroup
-     | Specifies a further group identifier to use for plugin lookup.
-    <pluginGroup>com.your.plugins</pluginGroup>
-    -->
-  </pluginGroups>
-
-  <!-- proxies
-   | This is a list of proxies which can be used on this machine to connect to the network.
-   | Unless otherwise specified (by system property or command-line switch), the first proxy
-   | specification in this list marked as active will be used.
-   |-->
-  <proxies>
-    <!-- proxy
-     | Specification for one proxy, to be used in connecting to the network.
-     |
-    <proxy>
-      <id>optional</id>
-      <active>true</active>
-      <protocol>http</protocol>
-      <username>proxyuser</username>
-      <password>proxypass</password>
-      <host>proxy.host.net</host>
-      <port>80</port>
-      <nonProxyHosts>local.net|some.host.com</nonProxyHosts>
-    </proxy>
-    -->
-  </proxies>
-
-  <!-- servers
-   | This is a list of authentication profiles, keyed by the server-id used within the system.
-   | Authentication profiles can be used whenever maven must make a connection to a remote server.
-   |-->
+<?xml version="1.0"?>
+<settings>
   <servers>
-    <!-- server
-     | Specifies the authentication information to use when connecting to a particular server, identified by
-     | a unique name within the system (referred to by the 'id' attribute below).
-     |
-     | NOTE: You should either specify username/password OR privateKey/passphrase, since these pairings are
-     |       used together.
-     |
     <server>
-      <id>deploymentRepo</id>
-      <username>repouser</username>
-      <password>repopwd</password>
+      <id>Exchange2</id>
+      <username>ANYPOINT_USERNAME</username>
+      <password>ANYPOINT_PASSWORD</password>
     </server>
-    -->
-
-    <!-- Another sample, using keys to authenticate.
     <server>
-      <id>siteServer</id>
-      <privateKey>/path/to/private/key</privateKey>
-      <passphrase>optional; leave empty if not used.</passphrase>
+      <id>anypoint-exchange-v3</id>
+      <username>ANYPOINT_USERNAME</username>
+      <password>ANYPOINT_PASSWORD</password>
     </server>
-    -->
-
-	<!-- MuleSoft Nexus EE Repository -->
-	<server>
-		<id>MuleRepository</id>
-		<!-- Provided by Support -->
-		<username>CUSTOMER_EE_REPO_USER</username>
-		<password>CUSTOMER_EE_REPO_PASS</password>
-	</server>
-	<!-- Customer Exchange Repository -->
-	<server>
-		<id>Exchange2</id>
-		<!-- NOTE: In order to be able to publish assets to exchange, this user will need Exchange Contributor Role -->
-		<username>ANYPOINT_PLATFORM_USER</username>
-		<password>ANYPOINT_PLATFORM_PASS</password>
-	</server>
+    <server>
+      <id>MuleRepository</id>
+      <username>CUSTOMER_EE_REPO_USERNAME</username>
+      <password>CUSTOMER_EE_REPO_PASSWORD</password>
+    </server>
   </servers>
 
-  <!-- mirrors
-   | This is a list of mirrors to be used in downloading artifacts from remote repositories.
-   |
-   | It works like this: a POM may declare a repository to use in resolving certain artifacts.
-   | However, this repository may have problems with heavy traffic at times, so people have mirrored
-   | it to several places.
-   |
-   | That repository definition will have a unique id, so we can create a mirror reference for that
-   | repository, to be used as an alternate download site. The mirror site will be the preferred
-   | server for that repository.
-   |-->
-  <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
-    <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
-    </mirror>
-     -->
-  </mirrors>
+  <pluginGroups>
+    <pluginGroup>org.mule.tools</pluginGroup>
+  </pluginGroups>
 
-  <!-- Profiles
-   | This is a list of profiles which can be activated in a variety of ways, and which can modify
-   | the build process. Profiles provided in the settings.xml are intended to provide local machine-
-   | specific paths and repository locations which allow the build to work in the local environment.
-   |
-   | For example, if you have an integration testing plugin - like cactus - that needs to know where
-   | your Tomcat instance is installed, you can provide a variable here such that the variable is
-   | dereferenced during the build process to configure the cactus plugin.
-   |
-   | As noted above, profiles can be activated in a variety of ways. One way - the activeProfiles
-   | section of this document (settings.xml) - will be discussed later. Another way essentially
-   | relies on the detection of a system property, either matching a particular value for the property,
-   | or merely testing its existence. Profiles can also be activated by JDK version prefix, where a
-   | value of '1.4' might activate a profile when the build is executed on a JDK version of '1.4.2_07'.
-   | Finally, the list of active profiles can be specified directly from the command line.
-   |
-   | NOTE: For profiles defined in the settings.xml, you are restricted to specifying only artifact
-   |       repositories, plugin repositories, and free-form properties to be used as configuration
-   |       variables for plugins in the POM.
-   |
-   |-->
   <profiles>
-    <!-- profile
-     | Specifies a set of introductions to the build process, to be activated using one or more of the
-     | mechanisms described above. For inheritance purposes, and to activate profiles via <activatedProfiles/>
-     | or the command line, profiles have to have an ID that is unique.
-     |
-     | An encouraged best practice for profile identification is to use a consistent naming convention
-     | for profiles, such as 'env-dev', 'env-test', 'env-production', 'user-jdcasey', 'user-brett', etc.
-     | This will make it more intuitive to understand what the set of introduced profiles is attempting
-     | to accomplish, particularly when you only have a list of profile id's for debug.
-     |
-     | This profile example uses the JDK version to trigger activation, and provides a JDK-specific repo.
     <profile>
-      <id>jdk-1.4</id>
-
+      <id>mule-extra-repos</id>
       <activation>
-        <jdk>1.4</jdk>
+        <activeByDefault>true</activeByDefault>
       </activation>
 
       <repositories>
         <repository>
-          <id>jdk14</id>
-          <name>Repository for JDK 1.4 builds</name>
-          <url>http://www.myhost.com/maven/jdk14</url>
-          <layout>default</layout>
-          <snapshotPolicy>always</snapshotPolicy>
+          <id>mule-public</id>
+          <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
         </repository>
       </repositories>
+
+      <pluginRepositories>
+        <pluginRepository>
+          <id>mule-public</id>
+          <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
+        </pluginRepository>
+      </pluginRepositories>
     </profile>
-    -->
 
-    <!--
-     | Here is another profile, activated by the system property 'target-env' with a value of 'dev',
-     | which provides a specific path to the Tomcat instance. To use this, your plugin configuration
-     | might hypothetically look like:
-     |
-     | ...
-     | <plugin>
-     |   <groupId>org.myco.myplugins</groupId>
-     |   <artifactId>myplugin</artifactId>
-     |
-     |   <configuration>
-     |     <tomcatLocation>${tomcatPath}</tomcatLocation>
-     |   </configuration>
-     | </plugin>
-     | ...
-     |
-     | NOTE: If you just wanted to inject this configuration whenever someone set 'target-env' to
-     |       anything, you could just leave off the <value/> inside the activation-property.
-     |
     <profile>
-      <id>env-dev</id>
-
+      <id>Mule</id>
       <activation>
-        <property>
-          <name>target-env</name>
-          <value>dev</value>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
 
-      <properties>
-        <tomcatPath>/path/to/tomcat/instance</tomcatPath>
-      </properties>
-    </profile>
-    -->
-		<profile>
-		    <id>Mule</id>
-		    <activation>
-		        <activeByDefault>true</activeByDefault>
-		    </activation>
-		    <repositories>
-		        <repository>
-		            <id>MuleRepository</id>
-		            <name>MuleRepository</name>
-		            <url>https://repository.mulesoft.org/nexus-ee/content/repositories/releases-ee/</url>
-		            <layout>default</layout>
-		            <releases>
-		                <enabled>true</enabled>
-		            </releases>
-		            <snapshots>
-		                <enabled>true</enabled>
-		            </snapshots>
-		        </repository>
-		    </repositories>
-		</profile>
-  </profiles>
+      <repositories>
+        <repository>
+          <id>MuleRepository</id>
+          <name>MuleRepository</name>
+          <url>https://repository.mulesoft.org/nexus-ee/content/repositories/releases-ee/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
 
-  <!-- activeProfiles
-   | List of profiles that are active for all builds.
-   |
-  <activeProfiles>
-    <activeProfile>alwaysActiveProfile</activeProfile>
-    <activeProfile>anotherAlwaysActiveProfile</activeProfile>
-  </activeProfiles>
-  -->
+        <repository>
+          <id>MuleRepositoryPublic</id>
+          <name>MuleRepositoryPublic</name>
+          <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+
+    </profile>
+  </profiles>
 </settings>


### PR DESCRIPTION
# JSON Logger 2.0.1 Vulnerabilities Fixed in this PR

## Critical Severity

- ✗ XML External Entity (XXE) Injection [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLWOODSTOX-2928754] in com.fasterxml.woodstox:woodstox-core@5.0.2
    introduced by org.mule.services:mule-service-weave:mule-service@2.1.2 > org.mule.weave:runtime@2.1.2 > org.mule.weave:core-modules@2.1.2 > com.fasterxml.woodstox:woodstox-core@5.0.2
  This issue was fixed in versions: 5.3.0
- ✗ Remote Code Execution (RCE) [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGMULERUNTIME-1089453] in org.mule.runtime:mule-core@4.1.1
    introduced by org.mule.runtime:mule-core@4.1.1
  This issue was fixed in versions: 4.3.0
- ✗ XML External Entity (XXE) Injection [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGMULERUNTIME-1089455] in org.mule.runtime:mule-core@4.1.1
    introduced by org.mule.runtime:mule-core@4.1.1
  This issue was fixed in versions: 4.3.0
- ✗ Remote Code Execution [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751] in org.springframework:spring-beans@5.1.6.RELEASE
    introduced by org.mule.connectors:mule-jms-connector:mule-plugin@1.6.3 > org.mule.connectors:mule-jms-client@1.6.2 > org.springframework:spring-jms@5.1.6.RELEASE > org.springframework:spring-beans@5.1.6.RELEASE
  This issue was fixed in versions: 5.2.20, 5.3.18

## High Severity

- ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-2806360] in org.yaml:snakeyaml@1.18
    introduced by org.mule.runtime:mule-core@4.1.1 > org.yaml:snakeyaml@1.18
  This issue was fixed in versions: 1.31
- ✗ XML External Entity (XXE) Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1048302] in com.fasterxml.jackson.core:jackson-databind@2.10.3
    introduced by com.fasterxml.jackson.core:jackson-databind@2.10.3
- ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.10.3
    introduced by com.fasterxml.jackson.core:jackson-databind@2.10.3
- ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-1078499] in net.minidev:json-smart@2.3
    introduced by com.jayway.jsonpath:json-path@2.4.0 > net.minidev:json-smart@2.3
- ✗ XML External Entity (XXE) Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-DOM4J-174153] in dom4j:dom4j@1.6.1
    introduced by org.mule.runtime:mule-module-extensions-spring-support@4.1.1 > dom4j:dom4j@1.6.1
  No upgrade or patch available
- ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-2841369] in org.json:json@20160810
    introduced by org.mule.runtime:mule-metadata-model-json@1.1.1 > org.everit.json:org.everit.json.schema@1.5.0 > org.json:json@20160810
  This issue was fixed in versions: 20180130
- ✗ XML External Entity (XXE) Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-DOM4J-2812975] in dom4j:dom4j@1.6.1
    introduced by org.mule.runtime:mule-module-extensions-spring-support@4.1.1 > dom4j:dom4j@1.6.1
  No upgrade or patch available
- ✗ XML External Entity (XXE) Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLBEANS-1060048] in org.apache.xmlbeans:xmlbeans@2.6.0
    introduced by org.mule.runtime:mule-metadata-model-xml@1.1.1 > org.apache.xmlbeans:xmlbeans@2.6.0
  This issue was fixed in versions: 3.0.0

## Medium Severity

- ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424] in com.fasterxml.jackson.core:jackson-databind@2.10.3
    introduced by com.fasterxml.jackson.core:jackson-databind@2.10.3
- ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426] in com.fasterxml.jackson.core:jackson-databind@2.10.3
    introduced by com.fasterxml.jackson.core:jackson-databind@2.10.3
- ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.10.3
    introduced by com.fasterxml.jackson.core:jackson-databind@2.10.3
- ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-1298655] in net.minidev:json-smart@2.3
    introduced by com.jayway.jsonpath:json-path@2.4.0 > net.minidev:json-smart@2.3
- ✗ Deserialization of Untrusted Data [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327] in com.google.code.gson:gson@2.8.5
    introduced by com.mulesoft.muleesb.modules:anypoint-mq-rest-client@3.1.0 > com.google.code.gson:gson@2.8.5
  This issue was fixed in versions: 2.8.9
- ✗ Directory Traversal [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109] in commons-io:commons-io@2.6
    introduced by org.mule.connectors:mule-jms-connector:mule-plugin@1.6.3 > commons-io:commons-io@2.6
  This issue was fixed in versions: 2.7
- ✗ Server-side Request Forgery (SSRF) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGMULERUNTIME-1089457] in org.mule.runtime:mule-core@4.1.1
    introduced by org.mule.runtime:mule-core@4.1.1
  This issue was fixed in versions: 4.3.0
- ✗ Improper Output Neutralization for Logs [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097] in org.springframework:spring-core@5.0.4.RELEASE
    introduced by com.mulesoft.muleesb.modules:anypoint-mq-rest-client@3.1.0 > org.springframework:spring-core@5.0.4.RELEASE
  This issue was fixed in versions: 5.3.12, 5.2.18
- ✗ Improper Input Validation [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878] in org.springframework:spring-core@5.0.4.RELEASE
    introduced by com.mulesoft.muleesb.modules:anypoint-mq-rest-client@3.1.0 > org.springframework:spring-core@5.0.4.RELEASE
  This issue was fixed in versions: 5.2.19.RELEASE, 5.3.14
- ✗ Multipart Content Pollution [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-460644] in org.springframework:spring-core@5.0.4.RELEASE
    introduced by com.mulesoft.muleesb.modules:anypoint-mq-rest-client@3.1.0 > org.springframework:spring-core@5.0.4.RELEASE
  This issue was fixed in versions: 4.3.14.RELEASE, 5.0.5.RELEASE
- ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828] in org.springframework:spring-expression@4.1.9.RELEASE
    introduced by org.mule.runtime:mule-module-extensions-spring-support@4.1.1 > org.mule.runtime:mule-module-spring-config@4.1.1 > org.springframework:spring-context@4.1.9.RELEASE > org.springframework:spring-expression@4.1.9.RELEASE
  This issue was fixed in versions: 5.2.20.RELEASE, 5.3.17
- ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313] in org.springframework:spring-beans@5.1.6.RELEASE
    introduced by org.mule.connectors:mule-jms-connector:mule-plugin@1.6.3 > org.mule.connectors:mule-jms-client@1.6.2 > org.springframework:spring-jms@5.1.6.RELEASE > org.springframework:spring-beans@5.1.6.RELEASE
  This issue was fixed in versions: 5.2.22.RELEASE, 5.3.20
- ✗ Improper Handling of Case Sensitivity [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634] in org.springframework:spring-context@4.1.9.RELEASE
    introduced by org.mule.runtime:mule-module-extensions-spring-support@4.1.1 > org.mule.runtime:mule-module-spring-config@4.1.1 > org.springframework:spring-context@4.1.9.RELEASE
  This issue was fixed in versions: 5.2.21, 5.3.19
- ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823310] in org.springframework:spring-messaging@5.1.6.RELEASE
    introduced by org.mule.connectors:mule-jms-connector:mule-plugin@1.6.3 > org.mule.connectors:mule-jms-client@1.6.2 > org.springframework:spring-jms@5.1.6.RELEASE > org.springframework:spring-messaging@5.1.6.RELEASE
  This issue was fixed in versions: 5.2.22.RELEASE, 5.3.20
- ✗ Stack-based Buffer Overflow [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3016891] in org.yaml:snakeyaml@1.18
    introduced by org.mule.runtime:mule-core@4.1.1 > org.yaml:snakeyaml@1.18
  This issue was fixed in versions: 1.31
- ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-537645] in org.yaml:snakeyaml@1.18
    introduced by org.mule.runtime:mule-core@4.1.1 > org.yaml:snakeyaml@1.18
  This issue was fixed in versions: 1.26

## Low Severity
  
- ✗ Information Disclosure [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415] in com.google.guava:guava@25.1-jre
    introduced by org.mule.connectors:mule-jms-connector:mule-plugin@1.6.3 > com.google.guava:guava@25.1-jre
  This issue was fixed in versions: 30.0-android, 30.0-jre
- ✗ Stack-based Buffer Overflow [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3016888] in org.yaml:snakeyaml@1.18
    introduced by org.mule.runtime:mule-core@4.1.1 > org.yaml:snakeyaml@1.18
  This issue was fixed in versions: 1.32
- ✗ Stack-based Buffer Overflow [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3016889] in org.yaml:snakeyaml@1.18
    introduced by org.mule.runtime:mule-core@4.1.1 > org.yaml:snakeyaml@1.18
  This issue was fixed in versions: 1.31